### PR TITLE
feat: add simple React Native login component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,13 @@
+# React Native Simple Login Component
+
+This repository contains a simple React Native component `SimpleLogin` that provides a basic login form with username and password fields and a login button.
+
+## Usage
+
+```javascript
+import SimpleLogin from './src/SimpleLogin';
+
+<SimpleLogin onLogin={(credentials) => console.log(credentials)} />
+```
+
+The `onLogin` callback receives an object containing `username` and `password`.

--- a/src/SimpleLogin.js
+++ b/src/SimpleLogin.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+
+const SimpleLogin = ({ onLogin }) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = () => {
+    if (onLogin) {
+      onLogin({ username, password });
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        style={styles.input}
+        placeholder="Username"
+        value={username}
+        onChangeText={setUsername}
+        autoCapitalize="none"
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+      />
+      <Button title="Login" onPress={handleLogin} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+});
+
+export default SimpleLogin;


### PR DESCRIPTION
## Summary
- add SimpleLogin component for React Native
- document usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c445a8a88332a1af4322d6f34d39