### PR TITLE
feat: connect login to REST endpoint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,10 @@ This repository contains a simple React Native component `SimpleLogin` that prov
 ```javascript
 import SimpleLogin from './src/SimpleLogin';
 
-<SimpleLogin onLogin={(credentials) => console.log(credentials)} />
+<SimpleLogin
+  endpoint="https://example.com/api/login"
+  onLogin={(response) => console.log(response)}
+/>
 ```
 
-The `onLogin` callback receives an object containing `username` and `password`.
+The component posts the `username` and `password` to the provided REST endpoint. The `onLogin` callback receives the parsed JSON response from the server.

--- a/src/SimpleLogin.js
+++ b/src/SimpleLogin.js
@@ -1,13 +1,25 @@
 import React, { useState } from 'react';
 import { View, TextInput, Button, StyleSheet } from 'react-native';
 
-const SimpleLogin = ({ onLogin }) => {
+const SimpleLogin = ({ endpoint = 'https://example.com/api/login', onLogin }) => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
 
-  const handleLogin = () => {
-    if (onLogin) {
-      onLogin({ username, password });
+  const handleLogin = async () => {
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ username, password }),
+      });
+      const data = await response.json();
+      if (onLogin) {
+        onLogin(data);
+      }
+    } catch (error) {
+      console.error('Login request failed', error);
     }
   };
 


### PR DESCRIPTION
## Summary
- post login credentials to a REST API using fetch
- document endpoint prop usage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c6179790833286374923d6c3e8b1