### PR TITLE
feat: agregar ficha persona

### DIFF
--- a/dist/js/vistas/Caracteristica.js
+++ b/dist/js/vistas/Caracteristica.js
@@ -1,0 +1,8 @@
+import React from "../libs/MiReact.js";
+export default function Caracteristica() {
+    return React.createElement("tr", null,
+        React.createElement("td", null,
+            React.createElement("input", { type: "text", placeholder: "Etiqueta" })),
+        React.createElement("td", null,
+            React.createElement("input", { type: "text", placeholder: "Valor" })));
+}

--- a/dist/js/vistas/FichaPersona.js
+++ b/dist/js/vistas/FichaPersona.js
@@ -1,0 +1,84 @@
+import JappN from "../libs/JappN.js";
+import React from "../libs/MiReact.js";
+import Caracteristica from "./Caracteristica.js";
+export default class FichaPersona extends JappN {
+    alCargar(props) {
+        return React.createElement("div", { class: "fpanel", id: "pv_fichapersona" },
+            React.createElement("h3", null, "Ficha de persona"),
+            React.createElement("div", { class: "row" },
+                React.createElement("div", { class: "col c4 i" },
+                    React.createElement("img", { id: "fp_foto", src: "", style: "max-width:100%" }),
+                    React.createElement("input", { type: "file", accept: "image/*", onChange: (e) => this.cargarImagen(e) })),
+                React.createElement("div", { class: "col c8" },
+                    React.createElement("table", { class: "frm" },
+                        React.createElement("tr", null,
+                            React.createElement("th", null, "Nombre"),
+                            React.createElement("td", null,
+                                React.createElement("input", { type: "text", id: "fp_nombre" }))),
+                        React.createElement("tr", null,
+                            React.createElement("th", null, "Apellido"),
+                            React.createElement("td", null,
+                                React.createElement("input", { type: "text", id: "fp_apellido" }))),
+                        React.createElement("tr", null,
+                            React.createElement("th", null, "Estado civil"),
+                            React.createElement("td", null,
+                                React.createElement("select", { id: "fp_estado" },
+                                    React.createElement("option", { value: "Casado" }, "Casado"),
+                                    React.createElement("option", { value: "Soltero" }, "Soltero"),
+                                    React.createElement("option", { value: "Divorciado" }, "Divorciado"),
+                                    React.createElement("option", { value: "Viudo" }, "Viudo"))))))),
+            React.createElement("div", null,
+                React.createElement("h4", null, "Caracter\u00EDsticas"),
+                React.createElement("table", { class: "frm", id: "fp_caracteristicas" }),
+                React.createElement("button", { onClick: () => this.agregarCaracteristica() }, "Agregar caracter\u00EDstica")),
+            React.createElement("div", null,
+                React.createElement("button", { onClick: () => this.enviarFicha() }, "Enviar")));
+    }
+    alCargado(el) {
+        this.el = el;
+    }
+    cargarImagen(e) {
+        const input = e.target;
+        const file = input.files && input.files[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = (ev) => {
+                const img = this.el.querySelector("#fp_foto");
+                img.src = ev.target.result;
+            };
+            reader.readAsDataURL(file);
+        }
+    }
+    agregarCaracteristica() {
+        const tabla = this.el.querySelector("#fp_caracteristicas");
+        tabla.append(React.createElement(Caracteristica, null));
+    }
+    enviarFicha() {
+        const img = this.el.querySelector("#fp_foto");
+        const data = {
+            fotografia: img.src,
+            nombre: this.el.querySelector("#fp_nombre").value,
+            apellido: this.el.querySelector("#fp_apellido").value,
+            estadoCivil: this.el.querySelector("#fp_estado").value,
+            caracteristicas: []
+        };
+        const filas = this.el.querySelectorAll("#fp_caracteristicas tr");
+        filas.forEach((f) => {
+            const inputs = f.querySelectorAll("input");
+            data.caracteristicas.push({
+                label: inputs[0].value,
+                valor: inputs[1].value
+            });
+        });
+        fetch("http://localhost:8080/Persona", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                token: "1278129384102938492",
+                _schema: "dev",
+                namespace: "midiendo"
+            },
+            body: JSON.stringify(data)
+        });
+    }
+}

--- a/src/js/vistas/Caracteristica.tsx
+++ b/src/js/vistas/Caracteristica.tsx
@@ -1,0 +1,8 @@
+import React from "../libs/MiReact.js";
+
+export default function Caracteristica(){
+    return <tr>
+        <td><input type="text" placeholder="Etiqueta"/></td>
+        <td><input type="text" placeholder="Valor"/></td>
+    </tr>;
+}

--- a/src/js/vistas/FichaPersona.tsx
+++ b/src/js/vistas/FichaPersona.tsx
@@ -1,0 +1,91 @@
+import JappN from "../libs/JappN.js";
+import React from "../libs/MiReact.js";
+import Caracteristica from "./Caracteristica.js";
+
+export default class FichaPersona extends JappN{
+
+    alCargar(props){
+        return <div class="fpanel" id="pv_fichapersona">
+            <h3>Ficha de persona</h3>
+            <div class="row">
+                <div class="col c4 i">
+                    <img id="fp_foto" src="" style="max-width:100%"/>
+                    <input type="file" accept="image/*" onChange={(e)=>this.cargarImagen(e)} />
+                </div>
+                <div class="col c8">
+                    <table class="frm">
+                        <tr><th>Nombre</th><td><input type="text" id="fp_nombre"/></td></tr>
+                        <tr><th>Apellido</th><td><input type="text" id="fp_apellido"/></td></tr>
+                        <tr><th>Estado civil</th><td>
+                            <select id="fp_estado">
+                                <option value="Casado">Casado</option>
+                                <option value="Soltero">Soltero</option>
+                                <option value="Divorciado">Divorciado</option>
+                                <option value="Viudo">Viudo</option>
+                            </select>
+                        </td></tr>
+                    </table>
+                </div>
+            </div>
+            <div>
+                <h4>Características</h4>
+                <table class="frm" id="fp_caracteristicas"></table>
+                <button onClick={()=>this.agregarCaracteristica()}>Agregar característica</button>
+            </div>
+            <div>
+                <button onClick={()=>this.enviarFicha()}>Enviar</button>
+            </div>
+        </div>;
+    }
+
+    alCargado(el){
+        this.el = el;
+    }
+
+    cargarImagen(e){
+        const input:any = e.target;
+        const file = input.files && input.files[0];
+        if(file){
+            const reader = new FileReader();
+            reader.onload = (ev)=>{
+                const img:any = this.el.querySelector("#fp_foto");
+                img.src = ev.target.result as string;
+            };
+            reader.readAsDataURL(file);
+        }
+    }
+
+    agregarCaracteristica(){
+        const tabla:any = this.el.querySelector("#fp_caracteristicas");
+        tabla.append(<Caracteristica />);
+    }
+
+    enviarFicha(){
+        const img:any = this.el.querySelector("#fp_foto");
+        const data:any = {
+            fotografia: img.src,
+            nombre: (this.el.querySelector("#fp_nombre") as any).value,
+            apellido: (this.el.querySelector("#fp_apellido") as any).value,
+            estadoCivil: (this.el.querySelector("#fp_estado") as any).value,
+            caracteristicas: [] as any[]
+        };
+        const filas = this.el.querySelectorAll("#fp_caracteristicas tr");
+        filas.forEach((f:any)=>{
+            const inputs = f.querySelectorAll("input");
+            data.caracteristicas.push({
+                label: inputs[0].value,
+                valor: inputs[1].value
+            });
+        });
+        fetch("http://localhost:8080/Persona", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                token: "1278129384102938492",
+                _schema: "dev",
+                namespace: "midiendo"
+            },
+            body: JSON.stringify(data)
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add FichaPersona component with photo upload, names, civil status and dynamic characteristics
- add Caracteristica row component used by FichaPersona
- send ficha persona data to REST endpoint with required headers

## Testing
- `npx tsc`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3cae312dc83328b81e73334becd7c